### PR TITLE
Make a `v1.1.2` to address release tarball

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gsm.datasim
 Title: Synthetic Test Data Generator
-Version: 1.1.1
+Version: 1.1.2
 Authors@R: c(
     person("Roman", "Rogoza", email = "roman.rogoza@atorusresearch.com", role = c("aut", "cre")),
     person("Laura", "Maxwell", email = "laura.maxwell@atorusresearch.com", role = c("aut")),


### PR DESCRIPTION
The `v1.1.1` tag is slightly misaligned, the PR upversions it to `v1.1.2` to allow us to properly release

Post merge, a release tag `v1.1.2` can be drawn off `main`
