### PR TITLE
Migrate workflow runtime from gsm.core to workr (#118)

### DIFF
--- a/pkgdown/menus/examples/example_workflow_driven.Rmd
+++ b/pkgdown/menus/examples/example_workflow_driven.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Workflow-Driven Data Generation"
 author: "[gsm.datasim](https://gilead-biostats.github.io/gsm.datasim) Example"
-description: "Generate simulated raw data directly from an lWorkflows spec — the same structure returned by gsm.core::MakeWorkflowList(). Covers single-snapshot, longitudinal, domain subsetting, and custom/unknown domains."
+description: "Generate simulated raw data directly from an lWorkflows spec — the same structure returned by workr::MakeWorkflowList(). Covers single-snapshot, longitudinal, domain subsetting, and custom/unknown domains."
 index: 4
 date: "`r format(Sys.time(), '%B %d, %Y %H:%M:%S %Z')`"
 output: html_document
@@ -19,7 +19,7 @@ library(gsm.datasim)
 ## Overview
 
 `generate_data_from_workflows()` accepts an `lWorkflows` list — the same
-structure returned by `gsm.core::MakeWorkflowList()` — and produces `Raw_*`
+structure returned by `workr::MakeWorkflowList()` — and produces `Raw_*`
 data frames for every domain defined in those specs.
 
 Domains with dedicated generators (`Raw_AE`, `Raw_SUBJ`, etc.) use curated
@@ -30,7 +30,7 @@ without extra code.
 ## Load Workflows from gsm.mapping
 
 ```{r load-workflows}
-lWorkflows <- gsm.core::MakeWorkflowList(
+lWorkflows <- workr::MakeWorkflowList(
   strPath    = "workflow/1_mappings",
   strPackage = "gsm.mapping"
 )

--- a/pkgdown/menus/examples/workflow_driven_generation.R
+++ b/pkgdown/menus/examples/workflow_driven_generation.R
@@ -2,14 +2,14 @@
 #
 # This example demonstrates how to generate simulated raw data directly from
 # an lWorkflows list — the same structure returned by
-# gsm.core::MakeWorkflowList(). Domains with existing generators (Raw_AE,
+# workr::MakeWorkflowList(). Domains with existing generators (Raw_AE,
 # Raw_SUBJ, etc.) use the curated logic; unknown domains fall back to
 # type-based column generation driven by the spec metadata.
 
 library(gsm.datasim)
 
 # ── 1. Load workflows from gsm.mapping ──────────────────────────────────────
-lWorkflows <- gsm.core::MakeWorkflowList(
+lWorkflows <- workr::MakeWorkflowList(
   strPath    = "workflow/1_mappings",
   strPackage = "gsm.mapping"
 )

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -7,8 +7,8 @@
 # * https://testthat.r-lib.org/articles/special-files.html
 
 library(testthat)
+library(workr)
 library(gsm.core)
-library(gsm.datasim)
 library(gsm.mapping)
 library(gsm.datasim)
 


### PR DESCRIPTION
## Summary

This PR began as the `gsm.datasim` side of the **gsm.core → workr** workflow-runtime migration (#118) — re-pointing `MakeWorkflowList` / `RunWorkflows` from `gsm.core::` to `workr::`.

While implementing it, we found that **#116 (`feat/111-remove-gsm-dependencies`) already performs that exact swap** — and more: it moves `gsm.core` and `gsm.mapping` to `Suggests`, renames `study_utils.R` → `gsm_utils.R`, regenerates `NAMESPACE`, and closes #111. Carrying our own copy of the swap would have duplicated and conflicted with that work.

So this PR was **rebased onto `feat/111` and reduced to only the pieces #116 did not cover** — i.e. it now cleans up the last remaining workr vestiges on top of your colleague's branch.

## What this PR now does (cleanup delta on top of #116)

- **`pkgdown/menus/examples/workflow_driven_generation.R`** and **`example_workflow_driven.Rmd`** — re-point the leftover `gsm.core::MakeWorkflowList()` references (comment, prose, and code) to `workr::MakeWorkflowList()`. (#116 did not touch `pkgdown/menus/`.)
- **`tests/testthat.R`** — load the `workr` runtime and drop a duplicated `library(gsm.datasim)`.

Net diff vs `feat/111`: **3 files, 6 lines.** The redundant `R/`, `DESCRIPTION`, and `NAMESPACE` changes from the original version were dropped in favor of #116's.

## Audit

After this change there are **no remaining `gsm.core::` workflow-runtime references** (`MakeWorkflowList`, `RunWorkflows`, `RunWorkflow`, `RunQuery`, `RunStep`) anywhere in the package. Vignette prose mentioning "gsm.core results" is intentionally left as-is — it describes the *analytics output*, whose functions (`Summarize`, `Analyze_*`) remain in `gsm.core`.

## Notes for reviewers

- **Base:** `feat/111-remove-gsm-dependencies` (stacked on #116), not `dev`. Merge #116 first.
- The substantive runtime swap that #118 asked for is delivered by #116; this PR finishes the remaining cleanup. Linking left as `Refs #118` so you/your colleague can decide which PR closes the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
