### PR TITLE
fix: update Gilead-BioStats links to Gilead-Public

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in contributing to the `gsm` suite of packages!
 
-This repository follows the **centralized `gsm` Contributor Guidelines** maintained in [`gsm.core`](https://gilead-biostats.github.io/gsm.core/CONTRIBUTING.html).  
+This repository follows the **centralized `gsm` Contributor Guidelines** maintained in [`gsm.core`](https://gilead-public.github.io/gsm.core/CONTRIBUTING.html).  
 Please review those guidelines before opening issues or submitting pull requests.
 
 ## Key Points
@@ -12,4 +12,4 @@ Please review those guidelines before opening issues or submitting pull requests
 - Track your issue on the [`gsm` Roadmap Project Board](https://github.com/orgs/Gilead-BioStats/projects/41).  
 - All code changes should be made in a branch and submitted as a PR following the guidelines linked above.  
   
-For detailed workflows (branching, releases, QC, CI/CD), please see the full [Contributor Guidelines in gsm.core](https://gilead-biostats.github.io/gsm.core/CONTRIBUTING.html).
+For detailed workflows (branching, releases, QC, CI/CD), please see the full [Contributor Guidelines in gsm.core](https://gilead-public.github.io/gsm.core/CONTRIBUTING.html).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,9 +12,9 @@ Description: Generates synthetic clinical trial data for testing and development
     longitudinal datasets across SDTM-style and custom domains, with optional
     analytics and reporting pipelines powered by the 'workr' workflow engine.
 License: Apache License (>= 2)
-URL: https://github.com/Gilead-BioStats/gsm.datasim,
-    https://gilead-biostats.github.io/gsm.datasim
-BugReports: https://github.com/Gilead-BioStats/gsm.datasim/issues
+URL: https://github.com/Gilead-Public/gsm.datasim,
+    https://gilead-public.github.io/gsm.datasim
+BugReports: https://github.com/Gilead-Public/gsm.datasim/issues
 Imports:
     arrow,
     dplyr,
@@ -39,10 +39,10 @@ Suggests:
 VignetteBuilder: 
     knitr
 Remotes:
-    gsm.kri=Gilead-BioStats/gsm.kri@dev,
-    gsm.mapping=Gilead-BioStats/gsm.mapping@dev,
-    gsm.reporting=Gilead-BioStats/gsm.reporting@dev,
-    workr=Gilead-BioStats/workr@main
+    gsm.kri=Gilead-Public/gsm.kri@dev,
+    gsm.mapping=Gilead-Public/gsm.mapping@dev,
+    gsm.reporting=Gilead-Public/gsm.reporting@dev,
+    workr=Gilead-Public/workr@main
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 Config/roxygen2/version: 8.0.0

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@
 
 <div class="pkgdown-release">
 
-[![R-CMD-check](https://github.com/Gilead-BioStats/gsm.datasim/actions/workflows/R-CMD-check.yaml/badge.svg?branch=main)](https://github.com/Gilead-BioStats/gsm.datasim/actions/workflows/R-CMD-check.yaml)
-[![test-coverage](https://github.com/Gilead-BioStats/gsm.datasim/actions/workflows/test-coverage.yaml/badge.svg?branch=main)](https://github.com/Gilead-BioStats/gsm.datasim/actions/workflows/test-coverage.yaml)
-[![pkgdown-all](https://github.com/Gilead-BioStats/gsm.datasim/actions/workflows/pkgdown-all.yaml/badge.svg?branch=main)](https://github.com/Gilead-BioStats/gsm.datasim/actions/workflows/pkgdown-all.yaml)
+[![R-CMD-check](https://github.com/Gilead-Public/gsm.datasim/actions/workflows/R-CMD-check.yaml/badge.svg?branch=main)](https://github.com/Gilead-Public/gsm.datasim/actions/workflows/R-CMD-check.yaml)
+[![test-coverage](https://github.com/Gilead-Public/gsm.datasim/actions/workflows/test-coverage.yaml/badge.svg?branch=main)](https://github.com/Gilead-Public/gsm.datasim/actions/workflows/test-coverage.yaml)
+[![pkgdown-all](https://github.com/Gilead-Public/gsm.datasim/actions/workflows/pkgdown-all.yaml/badge.svg?branch=main)](https://github.com/Gilead-Public/gsm.datasim/actions/workflows/pkgdown-all.yaml)
 
 </div>
 
 <div class="pkgdown-devel">
 
-[![R-CMD-check](https://github.com/Gilead-BioStats/gsm.datasim/actions/workflows/R-CMD-check.yaml/badge.svg?branch=dev)](https://github.com/Gilead-BioStats/gsm.datasim/actions/workflows/R-CMD-check.yaml)
-[![test-coverage](https://github.com/Gilead-BioStats/gsm.datasim/actions/workflows/test-coverage.yaml/badge.svg?branch=dev)](https://github.com/Gilead-BioStats/gsm.datasim/actions/workflows/test-coverage.yaml)
-[![pkgdown-all](https://github.com/Gilead-BioStats/gsm.datasim/actions/workflows/pkgdown-all.yaml/badge.svg?branch=dev)](https://github.com/Gilead-BioStats/gsm.datasim/actions/workflows/pkgdown-all.yaml)
+[![R-CMD-check](https://github.com/Gilead-Public/gsm.datasim/actions/workflows/R-CMD-check.yaml/badge.svg?branch=dev)](https://github.com/Gilead-Public/gsm.datasim/actions/workflows/R-CMD-check.yaml)
+[![test-coverage](https://github.com/Gilead-Public/gsm.datasim/actions/workflows/test-coverage.yaml/badge.svg?branch=dev)](https://github.com/Gilead-Public/gsm.datasim/actions/workflows/test-coverage.yaml)
+[![pkgdown-all](https://github.com/Gilead-Public/gsm.datasim/actions/workflows/pkgdown-all.yaml/badge.svg?branch=dev)](https://github.com/Gilead-Public/gsm.datasim/actions/workflows/pkgdown-all.yaml)
 
 </div>
 
@@ -27,7 +27,7 @@ development of clinical monitoring applications. It produces multi-snapshot
 longitudinal datasets across a configurable set of clinical domains
 (SDTM-style and custom) and can run configurable analytics and reporting
 pipelines on the generated data via the
-[`workr`](https://github.com/Gilead-BioStats/workr) workflow engine.
+[`workr`](https://github.com/Gilead-Public/workr) workflow engine.
 
 ## Installation
 
@@ -35,7 +35,7 @@ You can install the latest release of gsm.datasim from [GitHub](https://github.c
 
 ``` r
 # install.packages("pak")
-pak::pak("Gilead-BioStats/gsm.datasim@*release")
+pak::pak("Gilead-Public/gsm.datasim@*release")
 ```
 
 <div class="pkgdown-devel">
@@ -45,7 +45,7 @@ You can install the development version of gsm.datasim from
 
 ``` r
 # install.packages("pak")
-pak::pak("Gilead-BioStats/gsm.datasim")
+pak::pak("Gilead-Public/gsm.datasim")
 ```
 
 </div>

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: https://gilead-biostats.github.io/gsm.datasim/
+url: https://gilead-public.github.io/gsm.datasim/
 template:
   bootstrap: 5
 

--- a/man/generate_data_from_workflows.Rd
+++ b/man/generate_data_from_workflows.Rd
@@ -68,14 +68,14 @@ for custom distributions or categorical values.}
 }
 Example:
 \preformatted{
-column_overrides = list(
-  Raw_LB = list(
-    score_val  = function(n)    round(runif(n, 0, 10), 1),
-    lbstresu   = c("mg/dL", "mmol/L", "g/L"),
-    visit_flag = function(n, df) ifelse(df$visnam == "SCREENING", "S", "F")
+  column_overrides = list(
+    Raw_LB = list(
+      score_val  = function(n)    round(runif(n, 0, 10), 1),
+      lbstresu   = c("mg/dL", "mmol/L", "g/L"),
+      visit_flag = function(n, df) ifelse(df$visnam == "SCREENING", "S", "F")
+    )
   )
-)
-}}
+  }}
 }
 \value{
 When \code{snapshot_count == 1}, a named list of \code{data.frame}s (one per

--- a/man/gsm.datasim-package.Rd
+++ b/man/gsm.datasim-package.Rd
@@ -11,9 +11,9 @@ Generates synthetic clinical trial data for testing and development of clinical 
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://github.com/Gilead-BioStats/gsm.datasim}
-  \item \url{https://gilead-biostats.github.io/gsm.datasim}
-  \item Report bugs at \url{https://github.com/Gilead-BioStats/gsm.datasim/issues}
+  \item \url{https://github.com/Gilead-Public/gsm.datasim}
+  \item \url{https://gilead-public.github.io/gsm.datasim}
+  \item Report bugs at \url{https://github.com/Gilead-Public/gsm.datasim/issues}
 }
 
 }
@@ -22,7 +22,6 @@ Useful links:
 
 Authors:
 \itemize{
-  \item Laura Maxwell \email{laura.maxwell@atorusresearch.com}
   \item Zelos Zhu \email{zelos.zhu@atorusresearch.com}
   \item Roman Rogoza \email{roman.rogoza@atorusresearch.com}
 }

--- a/pkgdown/menus/examples/example_demo.Rmd
+++ b/pkgdown/menus/examples/example_demo.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "gsm.datasim Demo"
-author: "[gsm.datasim](https://gilead-biostats.github.io/gsm.datasim) Example"
+author: "[gsm.datasim](https://gilead-public.github.io/gsm.datasim) Example"
 description: "Full walkthrough of gsm.datasim: data generation, analytics, reporting, export, and multi-study workflows."
 index: 1
 date: "`r format(Sys.time(), '%B %d, %Y %H:%M:%S %Z')`"

--- a/pkgdown/menus/examples/example_domain_registry.Rmd
+++ b/pkgdown/menus/examples/example_domain_registry.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "Domain Registry"
-author: "[gsm.datasim](https://gilead-biostats.github.io/gsm.datasim) Example"
+author: "[gsm.datasim](https://gilead-public.github.io/gsm.datasim) Example"
 description: "How to inspect, use, and extend the Domain Registry for custom data generation."
 index: 3
 date: "`r format(Sys.time(), '%B %d, %Y %H:%M:%S %Z')`"

--- a/pkgdown/menus/examples/example_longitudinal.Rmd
+++ b/pkgdown/menus/examples/example_longitudinal.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "Longitudinal Data Generation"
-author: "[gsm.datasim](https://gilead-biostats.github.io/gsm.datasim) Example"
+author: "[gsm.datasim](https://gilead-public.github.io/gsm.datasim) Example"
 description: "Demonstrates quick-start, custom longitudinal studies, and the config API for multi-snapshot data generation."
 index: 2
 date: "`r format(Sys.time(), '%B %d, %Y %H:%M:%S %Z')`"

--- a/pkgdown/menus/examples/example_multiple_studies.Rmd
+++ b/pkgdown/menus/examples/example_multiple_studies.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "Generating Multiple Studies"
-author: "[gsm.datasim](https://gilead-biostats.github.io/gsm.datasim) Example"
+author: "[gsm.datasim](https://gilead-public.github.io/gsm.datasim) Example"
 description: "Shows three approaches to generating a portfolio of studies: identical configs, per-study vectors, and the study_portfolio() wrapper for variant-based configs."
 index: 4
 date: "`r format(Sys.time(), '%B %d, %Y %H:%M:%S %Z')`"

--- a/pkgdown/menus/examples/example_workflow_driven.Rmd
+++ b/pkgdown/menus/examples/example_workflow_driven.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "Workflow-Driven Data Generation"
-author: "[gsm.datasim](https://gilead-biostats.github.io/gsm.datasim) Example"
+author: "[gsm.datasim](https://gilead-public.github.io/gsm.datasim) Example"
 description: "Generate simulated raw data directly from an lWorkflows spec — the same structure returned by workr::MakeWorkflowList(). Covers single-snapshot, longitudinal, domain subsetting, and custom/unknown domains."
 index: 4
 date: "`r format(Sys.time(), '%B %d, %Y %H:%M:%S %Z')`"


### PR DESCRIPTION
## Summary
Updates all direct `Gilead-BioStats` org links to `Gilead-Public` across docs, config, and metadata files.

## Changes
- Replaced `github.com/Gilead-BioStats` → `github.com/Gilead-Public` in all applicable files.
- Replaced `gilead-biostats.github.io` → `gilead-public.github.io` in all applicable files.

## Intentional non-updated links
- `orgs/Gilead-BioStats/projects/41` in `.github/CONTRIBUTING.md` and issue templates — org-level project board, not a repo link.
- `github.com/Gilead-BioStats/gsm.roadmap` in `AGENTS.md` — `gsm.roadmap` has not moved to `Gilead-Public`.
- Descriptive mention of `Gilead-BioStats` org in `AGENTS.md` line 41 — historical context.

## Validation
- `grep -rn "Gilead-BioStats\|gilead-biostats.github.io" --exclude-dir=man .` returns no results for active docs/config.

Closes #135